### PR TITLE
Merge preliminary CVNP into Devel

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -50,6 +50,7 @@
 									<listOptionValue builtIn="false" value="${CG_TOOL_ROOT}/include"/>
 								</option>
 								<option id="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compilerID.LITTLE_ENDIAN.43449873" name="Little endian code [See 'General' page to edit] (--little_endian, -me)" superClass="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compilerID.LITTLE_ENDIAN" useByScannerDiscovery="false" value="true" valueType="boolean"/>
+								<option id="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compilerID.C_DIALECT.1681075047" superClass="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compilerID.C_DIALECT" value="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compilerID.C_DIALECT.C99" valueType="enumerated"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__C_SRCS.1537468231" name="C Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__C_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__CPP_SRCS.1250263288" name="C++ Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__CPP_SRCS"/>
 								<inputType id="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__ASM_SRCS.462113679" name="Assembly Sources" superClass="com.ti.ccstudio.buildDefinitions.TMS470_18.1.compiler.inputType__ASM_SRCS"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Debug/*
 .*
 /Debug/
+src/cvnp/cvnp

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Debug/*
 .*
+/Debug/

--- a/src/cvnp/cvnp.c
+++ b/src/cvnp/cvnp.c
@@ -45,8 +45,8 @@ static tNonCHandler g_pNonCTable[CVNP_NONCOMPLIANT_BUF_SIZE];
 
 
 // This device's class and instance number
-static uint8_t g_myClass;
-static uint8_t g_myInst;
+static uint32_t g_myClass;
+static uint32_t g_myInst;
 
 
 
@@ -187,6 +187,29 @@ static bool _cvnp_handleNonC(tCanFrame *frame, uint32_t now) {
 	}
 
 	return hit;
+}
+
+
+
+/**
+ * Main init routine. Saves our class / instance info, binds common handlers,
+ * resets the multicast / standard query buffers, binds common ddefs, and
+ * initializes HAL.
+ */
+bool cvnp_start(uint32_t myClass, uint32_t myInst) {
+	g_myClass = myClass;
+	g_myInst = myInst;
+
+	// TODO: Write common handler routines to attach here
+
+	// clear buffers
+	for(int i=0; i<CVNP_MULTICAST_BUF_SIZE; i++)
+		g_pMulticastTable[i].valid = false;
+
+	for(int i=0; i<CVNP_STD_QUERY_BUF_SIZE; i++)
+		g_pStdQueryTable[i].valid = false;
+
+	return cvnpHal_init();
 }
 
 

--- a/src/cvnp/cvnp.c
+++ b/src/cvnp/cvnp.c
@@ -129,7 +129,7 @@ static inline void _cvnp_runDdefhandler(tCanFrame *frame, tCompliantId id) {
 		id.rinst = id.sinst;
 		id.scls = g_myClass;
 		id.sinst = g_myInst;
-		newFrame.id = cvnp_structToId(&id);
+		newFrame.id = cvnp_structToId(id);
 		newFrame.head.rtr = 0;
 		newFrame.head.ide = 1;
 		cvnpHal_sendFrame(newFrame);
@@ -390,6 +390,52 @@ void cvnp_tick(uint32_t now) {
 		}
 	}
 }
+
+
+
+
+/**
+ * Converts a numeric ID to a formatted ID structure. This has to be done
+ * manually versus bitfields as the order and position of bitfields is not
+ * guaranteed.
+ */
+inline tCompliantId cvnp_idToStruct(uint32_t id) {
+	tCompliantId ret;
+	ret.nonc = (id >> CVNP_NONC_POS) & 0x1;
+	ret.broad = (id >> CVNP_BROAD_POS) & 0x1;
+	ret.scls = (id >> CVNP_SCLS_POS) & CVNP_CLASS_LEN_MASK;
+	ret.sinst = (id >> CVNP_SINST_POS) & CVNP_INST_LEN_MASK;
+	ret.rcls = (id >> CVNP_RCLS_POS) & CVNP_CLASS_LEN_MASK;
+	ret.rinst = (id >> CVNP_RINST_POS) & CVNP_INST_LEN_MASK;
+	ret.ddef = (id >> CVNP_DDEF_POS) & CVNP_DDEF_LEN_MASK;
+
+	return ret;
+}
+
+
+
+/**
+ * Converts a formatted ID structure to a numeric id. This has to be done
+ * manually versus bitfields as the order and position of bitfields is not
+ * guaranteed.
+ */
+inline uint32_t cvnp_structToId(tCompliantId id) {
+	uint32_t ret = id.ddef; // Zero everything but the lowest token
+	ret |= id.broad << CVNP_BROAD_POS;
+	ret |= id.nonc << CVNP_NONC_POS;
+	ret |= id.scls << CVNP_SCLS_POS;
+	ret |= id.sinst << CVNP_SINST_POS;
+
+	ret |= id.rcls << CVNP_RCLS_POS;
+	ret |= id.rinst << CVNP_RINST_POS;
+
+	return ret;
+}
+
+
+
+
+
 
 
 

--- a/src/cvnp/cvnp.c
+++ b/src/cvnp/cvnp.c
@@ -17,28 +17,28 @@
  * Table of DDEF request handlers. Each entry in this table
  * corresponds to one handler for one ddef.
  */
-static void (*g_pfnDdefTable[CVNP_NUM_DDEF])(tCanFrame *frame);
+static bool (*g_pfnDdefTable[CVNP_NUM_DDEF])(tCanFrame *frame, uint32_t *pLen, uint32_t *pData);
 
 /**
  * Table of current multicast response handlers registered to
  * the system
  */
-static tMulticastHandler g_psMulticastTable[CVNP_MULTICAST_BUF_SIZE];
+static tQueryHandler g_pMulticastTable[CVNP_MULTICAST_BUF_SIZE];
 
 /**
  * Table of current standard query response handlers registered to
  * the system
  */
-static tStdHandler g_psStdQueryTable[CVNP_STD_QUERY_BUF_SIZE];
+static tQueryHandler g_pStdQueryTable[CVNP_STD_QUERY_BUF_SIZE];
 
 /**
  * Table of current broadcast handlers registered to
  * the system
  */
-static tBroadHandler g_psBroadcastTable[CVNP_BROADCAST_BUF_SIZE];
+static tBroadHandler g_pBroadcastTable[CVNP_BROADCAST_BUF_SIZE];
 
 /**
  * Table of current non-compliant frame handlers registered to
  * the system
  */
-static tNonCHandler g_psNonCTable[CVNP_NONCOMPLIANT_BUF_SIZE];
+static tNonCHandler g_pNonCTable[CVNP_NONCOMPLIANT_BUF_SIZE];

--- a/src/cvnp/cvnp.c
+++ b/src/cvnp/cvnp.c
@@ -17,7 +17,7 @@
  * Table of DDEF request handlers. Each entry in this table
  * corresponds to one handler for one ddef.
  */
-static bool (*g_pfnDdefTable[CVNP_NUM_DDEF])(tCanFrame *frame, uint32_t *pLen, uint32_t *pData);
+static bool (*g_pfnDdefTable[CVNP_NUM_DDEF])(tCanFrame *frame, uint32_t *pLen, uint8_t (*pData)[8]);
 
 /**
  * Table of current multicast response handlers registered to
@@ -42,3 +42,82 @@ static tBroadHandler g_pBroadcastTable[CVNP_BROADCAST_BUF_SIZE];
  * the system
  */
 static tNonCHandler g_pNonCTable[CVNP_NONCOMPLIANT_BUF_SIZE];
+
+
+// This device's class and instance number
+static uint8_t g_myClass;
+static uint8_t g_myInst;
+
+/**
+ * Dispatches a DDEF handler, while providing the simple calling interface
+ * offered to the handler.
+ */
+static inline void _cvnp_runDdefhandler(tCanFrame *frame, tCompliantId id) {
+	tCanFrame newFrame;
+
+	if(!g_pfnDdefTable[id.ddef]) {
+		// TODO: handle null ddef handler here
+	}
+
+	// Need to use specific len variable because you can't take a pointer
+	// to a bitfield
+	uint32_t len;
+	if((*g_pfnDdefTable[id.ddef])(frame, &len, &newFrame.data)) {
+		newFrame.head.dlc = len;
+
+		// move around the ID so it points back to whoever sent this request
+		id.rcls = id.scls;
+		id.rinst = id.sinst;
+		id.scls = g_myClass;
+		id.sinst = g_myInst;
+		newFrame.id = cvnp_structToId(&id);
+		newFrame.head.rtr = 0;
+		newFrame.head.ide = 1;
+		cvnpHal_sendFrame(newFrame);
+	}
+}
+
+
+
+/**
+ * Processes an incoming frame for use in the CVNP system. This function
+ * is responsible for dispatching and updating the different handlers and
+ * buffers in order to reflect the new frame.
+ */
+void cvnp_procFrame(tCanFrame *frame) {
+	tCompliantId id = cvnp_idToStruct(frame->id);
+
+	// True if the noncompliant bit is set or the frame uses an 11-bit (standard) id
+	bool isCompliant = !id.nonc || !frame->head.ide;
+
+	// True if the frame is specifically directed at this device, or is
+	// a multicast that includes this device
+	bool isForMe =
+			(!id.rcls || id.rcls==g_myClass ) &&
+			(!id.rinst || id.rinst==g_myInst);
+
+	if(isCompliant && isForMe) {
+		if(frame->head.rtr)
+			_cvnp_runDdefhandler(frame, id);
+		else if(id.broad) {
+			// For now this uses a linear search, as there probably won't
+			// be enough broadcast handlers to justify the effort of a
+			// binary search. In the future this may change, or different
+			// implementations be selectable via preprocessor commands
+			bool hit = false;
+			for(int i=0; i<CVNP_BROADCAST_BUF_SIZE; i++) {
+
+			}
+		}
+	}
+}
+
+
+
+
+
+
+
+
+
+

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -134,10 +134,13 @@ void cvnp_tick(uint32_t now);
 
 
 /**
- * Starts the CVNP system on this device. This will automatically call the
- * HAL initialization. Returns a zero value on success, nonzero otherwise.
+ * Starts the CVNP system on this device. This should be called after setting up
+ * broadcast and nonC handlers and initializing the DDEF table. This will clear
+ * the multicast and standard query buffer. This will automatically call the
+ * HAL initialization, and if successful begin listening and operating.
+ * Returns true on success, false otherwise.
  */
-uint32_t cvnp_start(uint32_t myClass, uint32_t myInst);
+bool cvnp_start(uint32_t myClass, uint32_t myInst);
 
 
 

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -1,7 +1,8 @@
 /*
  * cvnp.h
  *
- * Contains the interface for the CVNP protocol.
+ * Contains the interface for the CVNP protocol. The functions here are what should be called
+ * by application code to participate in the protocol.
  *
  *  Created on: Mar 6, 2019
  *      Author: Duemmer
@@ -23,13 +24,13 @@
  * to the bits of an integer ID.
  */
 typedef struct {
-    uint32_t broad : 1;
-    uint32_t nonc : 1;
-    uint32_t scls : 6;
-    uint32_t sinst : 4;
-    uint32_t rcls : 6;
-    uint32_t rinst : 4;
-    uint32_t ddef : 7;
+    uint32_t broad 	: 1;
+    uint32_t nonc 	: 1;
+    uint32_t scls 	: 6;
+    uint32_t sinst 	: 4;
+    uint32_t rcls 	: 6;
+    uint32_t rinst 	: 4;
+    uint32_t ddef 	: 7;
 } tCompliantId;
 
 
@@ -38,12 +39,12 @@ typedef struct {
  * Handler for noncompliant frames on the bus.
  */
 typedef struct {
-    uint32_t ui32Id;
-    uint32_t ui32LastRun;
-    uint32_t ui32Timeout : 31;
-    uint32_t bHasTimeout : 1;
+    uint32_t id;
+    uint32_t lastRun;
+    uint32_t timeout : 31;
+    uint32_t hasTimeout : 1;
     void (*pfnProcFrame)(tCanFrame *frame);
-    void (*pfnOnDeath)(bool bWasKilled);
+    void (*pfnOnDeath)(bool wasKilled);
 } tNonCHandler;
 
 
@@ -55,10 +56,10 @@ typedef struct {
  */
 typedef struct {
     tCompliantId id;                        // The Query that was sent with this handler
-    uint32_t ui32TimeToLive;                // Time in ms to keep this active before it is killed
-    uint32_t ui32Submitted;                 // Time in ms that the query was executed
+    uint32_t timeToLive;                	// Time in ms to keep this active before it is killed
+    uint32_t submittedAt;                 	// Time in ms that the query was executed
     void (*pfnProcFrame)(tCanFrame *frame); // function to be called on a hit
-    void (*pfnOnDeath)(bool bWasKilled);    // function to be called when this handler either times out or is kicked from the buffer
+    void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
 } tQueryHandler;
 
 
@@ -69,11 +70,11 @@ typedef struct {
  * the timeToLive expires.
  */
 typedef struct {
-     tCompliantId id;                        // The broadcast to listen on. Only looks at SCLS and DDEF.
-     uint32_t ui32TimeToLive;                // Time in ms to keep this active before it is killed
-     uint32_t ui32Submitted;                 // Time in ms that the query was executed
-     void (*pfnProcFrame)(tCanFrame *frame); // function to be called on a hit
-     void (*pfnOnDeath)(bool bWasKilled);    // function to be called when this handler either times out or is kicked from the buffer
+     tCompliantId id;                        	// The broadcast to listen on. Only looks at SCLS and DDEF.
+     uint32_t timeToLive;                		// Time in ms to keep this active before it is killed
+     uint32_t submittedAt;                 		// Time in ms that the query was executed
+     void (*pfnProcFrame)(tCanFrame *frame); 	// function to be called on a hit
+     void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
 } tBroadHandler;
 
 
@@ -85,17 +86,23 @@ typedef struct {
     uint32_t rcls : 6;
     uint32_t rinst : 4;
     uint32_t ddef : 7;
-    uint32_t ui32Timeout : 31;
-    uint32_t bDoesTimeOut : 1;
+    uint32_t timeout : 31;
+    uint32_t doesTimeOut : 1;
     void (*pfnProcFrame)(tCanFrame *frame); // function to be called on a hit
-    void (*pfnOnDeath)(bool bWasKilled);    // function to be called when this handler either times out or is kicked from the buffer
+    void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
 } tQueryInfo;
 
 
 /**
- * Sends a query on the bus
+ * Sends a compliant query on the bus. This will add the given handlers to the query
+ * handler buffer, format a can frame with the requisite ID and the given data, and send it
+ * out. When a frame is received that matches the request to this request, the handler will
+ * be invoked and passed that data. If a timeout period passes before a response is
+ * received or the handler is kicked from the buffer (normally due to insufficient buffer
+ * size), the onTimeput handler will be called, with an indication if it was killed or just
+ * timed out.
  */
-void cvnp_query(tQueryInfo *info, uint32_t ui32Len, uint8_t data[8]);
+void cvnp_query(tQueryInfo *info, uint32_t len, uint8_t *pData);
 
 
 /**
@@ -108,14 +115,14 @@ void cvnp_procFrame(tCanFrame *frame);
  * Starts the CVNP system on this device. This will automatically call the
  * HAL initialization. Returns a zero value on success, nonzero otherwise.
  */
-uint32_t cvnp_start(uint32_t ui32MyClass, uint32_t ui32MyInst);
+uint32_t cvnp_start(uint32_t myClass, uint32_t myInst);
 
 
 
 /**
  * Converts an integer ID to an ID structure with the bits broken out.
  */
-inline tCompliantId cvnp_idToStruct(uint32_t ui32Id);
+inline tCompliantId cvnp_idToStruct(uint32_t id);
 
 
 /**
@@ -130,7 +137,7 @@ inline uint32_t cvnp_structToId(tCompliantId *id);
  */
 void cvnp_registerBroadHandler(tBroadHandler *handler);
 void cvnp_registerNonCHandler(tNonCHandler *handler);
-void cvnp_registerDdefHandler(uint32_t ui32Ddef, void (*pfnHandler)(tCanFrame *frame));
+void cvnp_registerDdefHandler(uint32_t ddef, void (*pfnHandler)(tCanFrame *frame));
 
 #endif /* CVNP_CVNP_H_ */
 

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -18,6 +18,18 @@
 // Buffer and table sizes
 #define CVNP_NUM_DDEF                           128 // Number of DDEFs in the protocol
 
+// Standard DDEFS
+#define CVNP_DDEF_ERROR							0
+#define CVNP_DDEF_DEVINFO						1
+#define CVNP_DDEF_DEVNAME						2
+#define CVNP_DDEF_DEVVER						3
+#define CVNP_DDEF_RESET							4
+
+// Magic constant for a reset frame. The data must match this exactly
+// in order for that frame to be recognized and a reset to be performed.
+// This is to prevent accidental resets.
+#define CVNP_RESET_MAGIC						0x06D3BAAE
+
 /**
  * Represents a CVNP compliant frame ID. Note that the ordering
  * of these elements is not defined, so they cannot be directly mapped
@@ -39,9 +51,10 @@ typedef struct {
  * Handler for noncompliant frames on the bus.
  */
 typedef struct {
+    uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
     uint32_t id;
     uint32_t lastRun;
-    uint32_t timeout : 31;
+    uint32_t timeout : 30;
     uint32_t hasTimeout : 1;
     void (*pfnProcFrame)(tCanFrame *frame);
     void (*pfnOnDeath)(bool wasKilled);
@@ -55,8 +68,9 @@ typedef struct {
  * the timeToLive expires.
  */
 typedef struct {
+	uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
     tCompliantId id;                        // The Query that was sent with this handler
-    uint32_t timeToLive;                	// Time in ms to keep this active before it is killed
+    uint32_t timeToLive : 31;              	// Time in ms to keep this active before it is killed
     uint32_t submittedAt;                 	// Time in ms that the query was executed
     void (*pfnProcFrame)(tCanFrame *frame); // function to be called on a hit
     void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
@@ -70,8 +84,9 @@ typedef struct {
  * the timeToLive expires.
  */
 typedef struct {
+	 uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
      tCompliantId id;                        	// The broadcast to listen on. Only looks at SCLS and DDEF.
-     uint32_t timeToLive;                		// Time in ms to keep this active before it is killed
+     uint32_t timeToLive : 31;             		// Time in ms to keep this active before it is killed
      uint32_t submittedAt;                 		// Time in ms that the query was executed
      void (*pfnProcFrame)(tCanFrame *frame); 	// function to be called on a hit
      void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -18,6 +18,21 @@
 // Buffer and table sizes
 #define CVNP_NUM_DDEF                           128 // Number of DDEFs in the protocol
 
+
+// Token positions in a compliant ID word
+#define CVNP_NONC_POS							28
+#define CVNP_BROAD_POS							27
+#define CVNP_SCLS_POS							21
+#define CVNP_SINST_POS							17
+#define CVNP_RCLS_POS							11
+#define CVNP_RINST_POS							7
+#define CVNP_DDEF_POS							7
+
+// Token length masks. Assumes the lsb of the field is aligned with bit 0
+#define CVNP_CLASS_LEN_MASK						((1 << 6) - 1)
+#define CVNP_INST_LEN_MASK						((1 << 4) - 1)
+#define CVNP_DDEF_LEN_MASK						((1 << 7) - 1)
+
 // Standard DDEFS
 #define CVNP_DDEF_ERROR							0
 #define CVNP_DDEF_DEVINFO						1
@@ -156,7 +171,7 @@ inline tCompliantId cvnp_idToStruct(uint32_t id);
 /**
  * Converts an ID structure to an integer ID
  */
-inline uint32_t cvnp_structToId(tCompliantId *id);
+inline uint32_t cvnp_structToId(tCompliantId id);
 
 
 

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -169,13 +169,13 @@ bool cvnp_start(uint32_t myClass, uint32_t myInst);
 /**
  * Converts an integer ID to an ID structure with the bits broken out.
  */
-inline tCompliantId cvnp_idToStruct(uint32_t id);
+tCompliantId cvnp_idToStruct(uint32_t id);
 
 
 /**
  * Converts an ID structure to an integer ID
  */
-inline uint32_t cvnp_structToId(tCompliantId id);
+uint32_t cvnp_structToId(tCompliantId id);
 
 
 

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -25,6 +25,9 @@
 #define CVNP_DDEF_DEVVER						3
 #define CVNP_DDEF_RESET							4
 
+// Error constant byte for the error frame response
+#define CVNP_ERROR_CONST                        0xD8
+
 // Magic constant for a reset frame. The data must match this exactly
 // in order for that frame to be recognized and a reset to be performed.
 // This is to prevent accidental resets.

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -52,10 +52,9 @@ typedef struct {
  */
 typedef struct {
     uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
+    uint32_t timeout : 31; // Time in ms to keep this active before it is killed. Set to 0 to disable timeouts.
     uint32_t id;
     uint32_t lastRun;
-    uint32_t timeout : 30;
-    uint32_t hasTimeout : 1;
     void (*pfnProcFrame)(tCanFrame *frame);
     void (*pfnOnDeath)(bool wasKilled);
 } tNonCHandler;
@@ -69,8 +68,8 @@ typedef struct {
  */
 typedef struct {
 	uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
-    tCompliantId id;                        // The Query that was sent with this handler
-    uint32_t timeToLive : 31;              	// Time in ms to keep this active before it is killed
+	uint32_t timeToLive : 31;              	// Time in ms to keep this active before it is killed. Set to 0 to disable timeouts.
+	tCompliantId id;                        // The Query that was sent with this handler
     uint32_t submittedAt;                 	// Time in ms that the query was executed
     void (*pfnProcFrame)(tCanFrame *frame); // function to be called on a hit
     void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
@@ -86,10 +85,10 @@ typedef struct {
 typedef struct {
 	 uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
      tCompliantId id;                        	// The broadcast to listen on. Only looks at SCLS and DDEF.
-     uint32_t timeToLive : 31;             		// Time in ms to keep this active before it is killed
+     uint32_t timeout : 31;						// minimum time between matching frames that causes the onTimeout function to run. Set to 0 to ignore timeouts.
      uint32_t lastRun;                 			// Time in ms that the broadcast was last received
      void (*pfnProcFrame)(tCanFrame *frame); 	// function to be called on a hit
-     void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
+     void (*pfnOnTimeout)(void);    			// function to be called when this handler either times out or is kicked from the buffer
 } tBroadHandler;
 
 
@@ -131,7 +130,7 @@ void cvnp_procFrame(tCanFrame *frame);
  * Tick routine that should be called periodically by the HAL. Every
  * 10-50ms is a good time to use.
  */
-void cvnp_tick(uint32_t ui32Now);
+void cvnp_tick(uint32_t now);
 
 
 /**

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -18,6 +18,10 @@
 // Buffer and table sizes
 #define CVNP_NUM_DDEF                           128 // Number of DDEFs in the protocol
 
+// Internal error constant identifiers
+#define CVNP_INTERNAL_ERR_UNKNOWN				0
+#define CVNP_INTERNAL_ERR_BAD_RX_FRAME			1
+#define CVNP_INTERNAL_ERR_NO_NONC_HANDLER		2
 
 // Token positions in a compliant ID word
 #define CVNP_NONC_POS							28
@@ -181,7 +185,7 @@ inline uint32_t cvnp_structToId(tCompliantId id);
  */
 bool cvnp_registerBroadHandler(tBroadHandler *handler);
 bool cvnp_registerNonCHandler(tNonCHandler *handler);
-bool cvnp_registerDdefHandler(uint32_t ddef, void (*pfnHandler)(tCanFrame *frame));
+bool cvnp_registerDdefHandler(uint32_t ddef, bool (*pfnHandler)(tCanFrame *frame, uint32_t *pLen, uint8_t pData[8]));
 
 #endif /* CVNP_CVNP_H_ */
 

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -87,7 +87,7 @@ typedef struct {
 	 uint32_t valid : 1; // Set automatically by the CVNP dispatcher. 1 if this is a live handler, 0 otherwise
      tCompliantId id;                        	// The broadcast to listen on. Only looks at SCLS and DDEF.
      uint32_t timeToLive : 31;             		// Time in ms to keep this active before it is killed
-     uint32_t submittedAt;                 		// Time in ms that the query was executed
+     uint32_t lastRun;                 			// Time in ms that the broadcast was last received
      void (*pfnProcFrame)(tCanFrame *frame); 	// function to be called on a hit
      void (*pfnOnDeath)(bool wasKilled);    	// function to be called when this handler either times out or is kicked from the buffer
 } tBroadHandler;
@@ -126,6 +126,14 @@ void cvnp_query(tQueryInfo *info, uint32_t len, uint8_t *pData);
  */
 void cvnp_procFrame(tCanFrame *frame);
 
+
+/**
+ * Tick routine that should be called periodically by the HAL. Every
+ * 10-50ms is a good time to use.
+ */
+void cvnp_tick(uint32_t ui32Now);
+
+
 /**
  * Starts the CVNP system on this device. This will automatically call the
  * HAL initialization. Returns a zero value on success, nonzero otherwise.
@@ -144,6 +152,7 @@ inline tCompliantId cvnp_idToStruct(uint32_t id);
  * Converts an ID structure to an integer ID
  */
 inline uint32_t cvnp_structToId(tCompliantId *id);
+
 
 
 /**

--- a/src/cvnp/cvnp.h
+++ b/src/cvnp/cvnp.h
@@ -179,9 +179,9 @@ inline uint32_t cvnp_structToId(tCompliantId id);
  * Registers new handlers with the system. If another handler
  * with the same effective ID is already registered, it will be replaced.
  */
-void cvnp_registerBroadHandler(tBroadHandler *handler);
-void cvnp_registerNonCHandler(tNonCHandler *handler);
-void cvnp_registerDdefHandler(uint32_t ddef, void (*pfnHandler)(tCanFrame *frame));
+bool cvnp_registerBroadHandler(tBroadHandler *handler);
+bool cvnp_registerNonCHandler(tNonCHandler *handler);
+bool cvnp_registerDdefHandler(uint32_t ddef, void (*pfnHandler)(tCanFrame *frame));
 
 #endif /* CVNP_CVNP_H_ */
 

--- a/src/cvnp/cvnp_config.h
+++ b/src/cvnp/cvnp_config.h
@@ -3,7 +3,7 @@
  *
  * User configurations for the CVNP API. Only these values should
  * be changed by the end user. The defaults should be fine, but
- * strict memory requirements or high traffic may warrent changing
+ * strict memory requirements or high traffic may warrant changing
  * some parameters.
  *
  *  Created on: Mar 7, 2019

--- a/src/cvnp/cvnp_hal.h
+++ b/src/cvnp/cvnp_hal.h
@@ -41,9 +41,9 @@ void cvnpHal_sendFrame(tCanFrame frame);
 
 
 /**
- * Tick routine that should be called periodically
+ * Returns the current system timestamp, in ms
  */
-void cvnpHal_tick(uint32_t ui32Now);
+uint32_t cvnpHal_now();
 
 #endif /* CVNP_CVNP_HAL_H_ */
 

--- a/src/cvnp/cvnp_hal.h
+++ b/src/cvnp/cvnp_hal.h
@@ -45,6 +45,13 @@ void cvnpHal_sendFrame(tCanFrame frame);
  */
 uint32_t cvnpHal_now();
 
+
+/**
+ * Performs a system level reset, as requested by the RESET ddef. This
+ * reset should be a system-wide reset, though this isn't required.
+ */
+void cvnpHal_resetSystem();
+
 #endif /* CVNP_CVNP_HAL_H_ */
 
 

--- a/src/cvnp/cvnp_hal.h
+++ b/src/cvnp/cvnp_hal.h
@@ -29,9 +29,9 @@ typedef struct {
 
 
 /**
- * Initializes the bus hardware
+ * Initializes the bus hardware. Returns true if successful
  */
-void cvnpHal_init();
+bool cvnpHal_init();
 
 
 /**

--- a/src/cvnp/cvnp_hal.h
+++ b/src/cvnp/cvnp_hal.h
@@ -47,6 +47,15 @@ uint32_t cvnpHal_now();
 
 
 /**
+ * Called when an internal error is encountered by the CVNP
+ * library. Used mostly for debugging purposes. errNum will be
+ * one of the constants CVNP_INTERNAL_ERR_x, defined in cvnp.h
+ */
+void cvnpHal_handleError(uint32_t errNum);
+
+
+
+/**
  * Performs a system level reset, as requested by the RESET ddef. This
  * reset should be a system-wide reset, though this isn't required.
  */

--- a/src/cvnp/cvnp_test.c
+++ b/src/cvnp/cvnp_test.c
@@ -1,0 +1,29 @@
+/*
+ * cvnp_test.c
+ *
+ *	Unit testing for the core, platform independent CVNP library.
+ *	This is intended to be run on a fully-featured C system, not
+ *	on the embedded target.
+ *
+ *  Created on: Mar 22, 2019
+ *      Author: Duemmer
+ */
+
+#include "cvnp_config.h"
+
+/**
+ * Debug enable. If this constant is enabled, the CVNP debug routines
+ * will be included in the build. This includes a cvnp_hal implementation,
+ * test routines, and a main() function to run it. This is designed to
+ * run on a test bench setup, so printf, fprintf, fork, etc. are used.
+ * This constant will be set by cvnp_debug.make
+ */
+#ifdef CVNP_DEBUG_ENABLE
+
+#include "cvnp.h"
+#include "cvnp_hal.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#endif

--- a/src/cvnp/cvnp_test.c
+++ b/src/cvnp/cvnp_test.c
@@ -19,7 +19,7 @@
  * run on a test bench setup, so printf, fprintf, fork, etc. are used.
  * This constant will be set by cvnp_debug.make
  */
-#ifdef CVNP_DEBUG_ENABLE
+//#ifdef CVNP_DEBUG_ENABLE
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -29,6 +29,11 @@
 #include "cvnp_config.h"
 #include "cvnp_hal.h"
 #include "cvnp.h"
+
+#define MY_INST 1
+#define MY_CLASS 1
+
+char buf[1024]; // Read buffer
 
 // Pipes for communication between the CAN child and parent
 int p1[2], p2[2];
@@ -54,8 +59,54 @@ void cvnpHal_resetSystem() {
 
 }
 
-int main() {
 
+
+
+/**
+ * Main test routine for the CVNP main code
+ */
+void test_parent() {
+	// Setup pipes
+	bool didStart = cvnp_start(MY_CLASS, MY_INST);
+}
+
+
+/**
+ * Main test routine for the simulated CAN client. This will loop and receive
+ * input frames via the pipes, as well as send its own frames periodically
+ *
+ */
+void test_child() {
+
+}
+
+
+
+int main() {
+	pid_t proc;
+
+	// open pipes
+	if (pipe(p1)==-1)
+	{
+		fprintf(stderr, "Pipe Failed" );
+		return 1;
+	}
+	if (pipe(p2)==-1)
+	{
+		fprintf(stderr, "Pipe Failed" );
+		return 1;
+	}
+
+	// Fork
+	proc = fork();
+	if(p < 0)
+	{
+		fprintf(stderr, "fork Failed" );
+		return 1;
+	} else if(p > 0) // in the parent proc. Main CVNP control goes here
+		test_parent();
+	else // in the child proc. Simulated bus goes here
+		test_child();
 }
 
 

--- a/src/cvnp/cvnp_test.c
+++ b/src/cvnp/cvnp_test.c
@@ -3,13 +3,14 @@
  *
  *	Unit testing for the core, platform independent CVNP library.
  *	This is intended to be run on a fully-featured C system, not
- *	on the embedded target.
+ *	on the embedded target. This will create a child process for simulating
+ *	the CAN bus, which will send and receive various messages in order
+ *	to test the system
  *
  *  Created on: Mar 22, 2019
  *      Author: Duemmer
  */
 
-#include "cvnp_config.h"
 
 /**
  * Debug enable. If this constant is enabled, the CVNP debug routines
@@ -20,10 +21,50 @@
  */
 #ifdef CVNP_DEBUG_ENABLE
 
-#include "cvnp.h"
-#include "cvnp_hal.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include "cvnp_config.h"
+#include "cvnp_hal.h"
+#include "cvnp.h"
+
+// Pipes for communication between the CAN child and parent
+int p1[2], p2[2];
+
+// cvnp_hal implementations. Stubs for now.
+bool cvnpHal_init() {
+
+}
+
+void cvnpHal_sendFrame(tCanFrame frame) {
+
+}
+
+uint32_t cvnpHal_now() {
+
+}
+
+void cvnpHal_handleError(uint32_t errNum) {
+
+}
+
+void cvnpHal_resetSystem() {
+
+}
+
+int main() {
+
+}
+
+
+
+
+
+
+
+
+
 
 #endif

--- a/src/cvnp/makefile
+++ b/src/cvnp/makefile
@@ -1,0 +1,16 @@
+CC=gcc
+CFLAGS=-I. -Wall -Wextra -Wno-unused-parameter -DCVNP_DEBUG_ENABLE
+INC = cvnp.h cvnp_hal.h cvnp_config.h
+
+cvnp: cvnp.o cvnp_test.o
+	$(CC) -o cvnp cvnp.o cvnp_test.o
+	rm -rf *.o *.gch
+	
+cvnp.o: cvnp.c $(INC)
+	$(CC) -c cvnp.c $(CFLAGS)
+	
+cvnp_test.o: cvnp_test.c $(INC)
+	$(CC) -c cvnp_test.c $(CFLAGS)
+	
+clean:
+	rm -rf *.o *.gch cvnp


### PR DESCRIPTION
Merge the initial CVNP library into the main development flow so work can continue. CVNP is not yet properly tested, as software emulation and testing is too difficult and time consuming when a hardware mock can be constructed and signals probed with an oscilloscope. The assumption is that the main API will require minor, if any, changes, so this should be a relatively painless procedure. Considering how CVNP will most likely be migrated to its own repository anyways, further tweaking at the current moment is unnecessary. 